### PR TITLE
Gracefully handle submodule syncs

### DIFF
--- a/.github/actions/composite/setupGitForOSBotify/action.yml
+++ b/.github/actions/composite/setupGitForOSBotify/action.yml
@@ -8,9 +8,6 @@ inputs:
   OP_SERVICE_ACCOUNT_TOKEN:
     description: "1Password service account token"
     required: true
-  OP_VAULT:
-    description: "1Password vault to read the GPG private key from"
-    required: true
 
 runs:
   using: composite

--- a/.github/actions/composite/setupGitForOSBotifyApp/action.yml
+++ b/.github/actions/composite/setupGitForOSBotifyApp/action.yml
@@ -17,9 +17,6 @@ inputs:
   OS_BOTIFY_PRIVATE_KEY:
     description: "OS Botify's private key"
     required: true
-  OP_VAULT:
-    description: "1Password vault to read the GPG private key from"
-    required: true
 
 outputs:
   # Do not try to use this for committing code. Use `secrets.OS_BOTIFY_COMMIT_TOKEN` instead

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -31,7 +31,6 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
           OS_BOTIFY_PRIVATE_KEY: ${{ secrets.OS_BOTIFY_PRIVATE_KEY }}
-          OP_VAULT: ${{ vars.OP_VAULT }}
 
       - name: Get previous app version
         id: getPreviousVersion

--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -71,7 +71,6 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
           SETUP_AS_APP: false
-          OP_VAULT: ${{ vars.OP_VAULT }}
 
       - name: Generate new E/App version
         id: bumpVersion

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,6 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
           OS_BOTIFY_PRIVATE_KEY: ${{ secrets.OS_BOTIFY_PRIVATE_KEY }}
-          OP_VAULT: ${{ vars.OP_VAULT }}
 
       - name: Get app version
         id: getAppVersion

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -26,7 +26,6 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
           OS_BOTIFY_PRIVATE_KEY: ${{ secrets.OS_BOTIFY_PRIVATE_KEY }}
-          OP_VAULT: ${{ vars.OP_VAULT }}
 
       - name: Validate actor is deployer
         id: isDeployer
@@ -93,7 +92,6 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
           OS_BOTIFY_PRIVATE_KEY: ${{ secrets.OS_BOTIFY_PRIVATE_KEY }}
-          OP_VAULT: ${{ vars.OP_VAULT }}
 
       - name: Update production branch
         run: |
@@ -136,7 +134,6 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
           OS_BOTIFY_PRIVATE_KEY: ${{ secrets.OS_BOTIFY_PRIVATE_KEY }}
-          OP_VAULT: ${{ vars.OP_VAULT }}
 
       - name: Update staging branch to trigger staging deploy
         run: |

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -108,7 +108,6 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
           OS_BOTIFY_PRIVATE_KEY: ${{ secrets.OS_BOTIFY_PRIVATE_KEY }}
-          OP_VAULT: ${{ vars.OP_VAULT }}
 
       - name: Update staging branch from main
         run: |

--- a/.github/workflows/syncFork.yml
+++ b/.github/workflows/syncFork.yml
@@ -1,0 +1,62 @@
+# This workflow is used to sync the App-Test-Fork with the upstream automatically,
+# while keeping the Mobile-Expensify submodule pointed at Mobile-Expensify-Test-Fork.
+name: Sync fork
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.OS_BOTIFY_TOKEN }}
+
+      - name: Setup Git for OSBotify
+        uses: Expensify/GitHub-Actions/setupGitForOSBotify@main
+        with:
+          OP_VAULT: ${{ vars.OP_VAULT }}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
+          OS_BOTIFY_PRIVATE_KEY: ${{ secrets.OS_BOTIFY_PRIVATE_KEY }}
+
+      - name: Sync Mobile-Expensify-Test-Fork with upstream
+        run: gh repo sync Expensify/Mobile-Expensify-Test-Fork
+
+      - name: Get upstream Mobile-Expensify commit
+        id: getUpstreamSubmoduleCommit
+        run: |
+          git remote add upstream https://github.com/Expensify/App.git
+          git fetch upstream main --depth=1
+          UPSTREAM_SUBMODULE_COMMIT=$(git ls-tree upstream/main Mobile-Expensify | awk '{print $3}')
+          echo "UPSTREAM_SUBMODULE_COMMIT=$UPSTREAM_SUBMODULE_COMMIT" >> "$GITHUB_OUTPUT"
+
+      - name: Temporarily reset submodule to upstream's commit
+        run: |
+          git submodule update --init
+          git checkout ${{ steps.getUpstreamSubmoduleCommit.outputs.UPSTREAM_SUBMODULE_COMMIT }} Mobile-Expensify
+          git add Mobile-Expensify
+          git commit -m "Temporarily reset submodule to match upstream"
+
+      - name: Sync App-Test-Fork with upstream
+        run: gh repo sync Expensify/App-Test-Fork
+
+      - name: Point Mobile-Expensify submodule back to Mobile-Expensify-Test-Fork
+        run: |
+          # Ensure correct submodule URL
+          git config -f .gitmodules submodule.Mobile-Expensify.url git@github.com:Expensify/Mobile-Expensify-Test-Fork.git
+          git submodule sync
+
+          # Fetch the latest commit from Mobile-Expensify-Test-Fork
+          git fetch https://github.com/Expensify/Mobile-Expensify-Test-Fork.git main --depth=1
+          LATEST_SUBMODULE_COMMIT=$(git ls-remote https://github.com/Expensify/Mobile-Expensify-Test-Fork.git refs/heads/main | awk '{print $1}')
+
+          # Checkout the submodule to the latest commit
+          cd Mobile-Expensify
+          git checkout "$LATEST_SUBMODULE_COMMIT"
+          cd ..
+
+          git add .gitmodules Mobile-Expensify
+          git commit -m "Point Mobile-Expensify submodule to latest Mobile-Expensify-Test-Fork main"
+          git push origin main


### PR DESCRIPTION
### Explanation of Change
We don't want CI/CD testing in this fork to accidentally push real changes to E/Mobile-Expensify. To address this, we added a fork of Mobile-Expensify: https://github.com/Expensify/Mobile-Expensify-Test-Fork. However, the problem that arises is how we point this fork's Mobile-Expensify submodule at Mobile-Expensify-Test-Fork. Because the submodule config is committed, when we sync this fork with the upstream we'll either get conflicts or overwrite Mobile-Expensify submodule to point back at E/Mobile-Expensify upstream.

To address this, we will create a `workflow_dispatch` workflow called `syncFork` that will:

1. Sync the Mobile-Expensify-Test-Fork repo with its upstream Mobile-Expensify
2. Temporarily reset E/App-Test-Fork's submodule to match the upstream E/App's submodule (i.e: pointing at E/Mobile-Expensify, with the same commit that E/App main is pointing to).
3. Sync the E/App-Test-Fork. The previous step avoids conflicts in Mobile-Expensify, which usually will have been changed both in the fork and the upstream.
4. Update the E/App-Test-Fork submodule to point back at the latest main in Mobile-Expensify-Test-Fork

Let's walk through a few examples to convince ourself that this strategy makes sense and is sufficient to ensure that E/App-Test-Fork's Mobile-Expensify submodule will always point at E/Mobile-Expensify-Test-Fork.

#### Example 1
1. E/App's Mobile-Expensify submodule is pointed at E/Mobile-Expensify commit `a`, and E/App-Test-Fork is fully in-sync with the upstream E/App.
1. E/App-Test-Fork's Mobile-Expensify submodule is updated to point at E/Mobile-Expensify-Test-Fork's commit `b`
1. E/App's Mobile-Expensify submodule is updated to point at E/Mobile-Expensify commit `c`
1. Someone presses the `sync fork` button in E/App-Test-Fork. Since changes have been made to the Mobile-Expensify submodule both in the fork and the upstream, the sync can't be done automatically. So they then use the `syncFork` workflow to do it.

#### Example 2
1. E/App's Mobile-Expensify submodule is pointed at E/Mobile-Expensify commit `a`, and E/App-Test-Fork is fully in-sync with the upstream E/App.
1. E/App-Test-Fork's Mobile-Expensify submodule is updated to point at E/Mobile-Expensify-Test-Fork's commit `b`
1. Someone presses the `sync fork` button in E/App-Test-Fork, before E/App's Mobile-Expensify submodule has changed in the upstream. The sync completes automatically, and E/App-Test-Fork's Mobile-Expensify submodule is still pointed at E/Mobile-Expensify-Test-Fork's commit `b`.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
