### PR TITLE
Sync branch dance (v5)

### DIFF
--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -72,8 +72,6 @@ jobs:
         with:
           OP_VAULT: ${{ vars.OP_VAULT }}
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
-          OS_BOTIFY_PRIVATE_KEY: ${{ secrets.OS_BOTIFY_PRIVATE_KEY }}
           SETUP_AS_APP: false
 
       - name: Generate new E/App version

--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -83,7 +83,10 @@ jobs:
 
       - name: Generate HybridApp version
         run: |
+          # Checkout main branch in Mobile-Expensify submodule.
+          # This is IMPORTANT so that when we make changes, we aren't in a detached head state, and when we later push those changes to main, it works!
           cd Mobile-Expensify
+          git checkout main
 
           # Generate all flavors of the version
           SHORT_APP_VERSION=$(echo "$NEW_VERSION" | awk -F'-' '{print $1}')

--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -81,13 +81,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_COMMIT_TOKEN }}
           SEMVER_LEVEL: ${{ inputs.SEMVER_LEVEL }}
 
-      - name: Update Mobile-Expensify submodule with the latest state of the Mobile-Expensify main branch
-        run: |
-          cd Mobile-Expensify
-          git fetch --depth=1 origin main
-          git checkout main
-          git reset --hard origin/main
-
       - name: Generate HybridApp version
         run: |
           cd Mobile-Expensify

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,10 +118,6 @@ jobs:
           # fetch-depth: 0 is required in order to fetch the correct submodule branch
           fetch-depth: 0
 
-      - name: Update submodule to match main
-        run: |
-          git submodule update --init --remote
-
       - name: Configure MapBox SDK
         run: ./scripts/setup-mapbox-sdk.sh ${{ secrets.MAPBOX_SDK_DOWNLOAD_TOKEN }}
 
@@ -461,13 +457,8 @@ jobs:
           # fetch-depth: 0 is required in order to fetch the correct submodule branch
           fetch-depth: 0
 
-      - name: Update submodule
-        run: |
-          git submodule update --init --remote
-
       - name: Configure MapBox SDK
-        run: |
-          ./scripts/setup-mapbox-sdk.sh ${{ secrets.MAPBOX_SDK_DOWNLOAD_TOKEN }}
+        run: ./scripts/setup-mapbox-sdk.sh ${{ secrets.MAPBOX_SDK_DOWNLOAD_TOKEN }}
 
       - name: Setup Node
         id: setup-node

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -74,38 +74,11 @@ jobs:
 
   # Update the production branch to trigger the production deploy.
   updateProduction:
-    runs-on: ubuntu-latest
     needs: validate
-    if: ${{ fromJSON(needs.validate.outputs.isValid) }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: staging
-          token: ${{ secrets.OS_BOTIFY_TOKEN }}
-
-      - name: Setup git for OSBotify
-        id: setupGitForOSBotify
-        uses: Expensify/GitHub-Actions/setupGitForOSBotify@main
-        with:
-          OP_VAULT: ${{ vars.OP_VAULT }}
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
-          OS_BOTIFY_PRIVATE_KEY: ${{ secrets.OS_BOTIFY_PRIVATE_KEY }}
-
-      - name: Update production branch
-        run: |
-          # Re-create the production branch from staging
-          git switch -c production
-
-          # Force-update the remote production branch.
-          git push --force origin production
-
-      - name: Announce failed workflow in Slack
-        if: ${{ failure() }}
-        uses: ./.github/actions/composite/announceFailedWorkflowInSlack
-        with:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    uses: ./.github/workflows/updateProtectedBranch.yml
+    secrets: inherit
+    with:
+      TARGET_BRANCH: production
 
   # Create a new patch version to prep for next release cycle
   createNewPatchVersion:
@@ -118,33 +91,8 @@ jobs:
 
   # Update the staging branch to trigger a staging deploy
   updateStaging:
-    runs-on: ubuntu-latest
     needs: [updateProduction, createNewPatchVersion]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: main
-          token: ${{ secrets.OS_BOTIFY_TOKEN }}
-
-      - name: Setup git for OSBotify
-        uses: Expensify/GitHub-Actions/setupGitForOSBotify@main
-        with:
-          OP_VAULT: ${{ vars.OP_VAULT }}
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
-          OS_BOTIFY_PRIVATE_KEY: ${{ secrets.OS_BOTIFY_PRIVATE_KEY }}
-
-      - name: Update staging branch to trigger staging deploy
-        run: |
-          # Re-create the staging branch from main
-          git switch -c staging
-
-          # Force-update the remote staging branch
-          git push --force origin staging
-
-      - name: Announce failed workflow in Slack
-        if: ${{ failure() }}
-        uses: ./.github/actions/composite/announceFailedWorkflowInSlack
-        with:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    uses: ./.github/workflows/updateProtectedBranch.yml
+    secrets: inherit
+    with:
+      TARGET_BRANCH: staging

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -86,42 +86,10 @@ jobs:
 
   updateStaging:
     needs: [chooseDeployActions, createNewVersion]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run turnstyle
-        uses: softprops/turnstyle@49108bdfa571e62371bd2c3094893c547ab3fc03
-        with:
-          poll-interval-seconds: 10
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: Checkout main
-        uses: actions/checkout@v4
-        with:
-          ref: main
-          token: ${{ secrets.OS_BOTIFY_TOKEN }}
-
-      - name: Setup Git for OSBotify
-        uses: Expensify/GitHub-Actions/setupGitForOSBotify@main
-        with:
-          OP_VAULT: ${{ vars.OP_VAULT }}
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
-          OS_BOTIFY_PRIVATE_KEY: ${{ secrets.OS_BOTIFY_PRIVATE_KEY }}
-
-      - name: Update staging branch from main
-        run: |
-          # Re-create the staging branch from main
-          git switch -c staging
-
-          # Force-update the remote staging branch
-          git push --force origin staging
-
-      - name: Announce failed workflow in Slack
-        if: ${{ failure() }}
-        uses: ./.github/actions/composite/announceFailedWorkflowInSlack
-        with:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    uses: ./.github/workflows/updateProtectedBranch.yml
+    secrets: inherit
+    with:
+      TARGET_BRANCH: staging
 
   e2ePerformanceTests:
     needs: [chooseDeployActions]

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -7,37 +7,11 @@ on:
     paths-ignore: [docs/**, help/**, contributingGuides/**, jest/**, tests/**]
 
 jobs:
-  typecheck:
-    uses: ./.github/workflows/typecheck.yml
-
-  lint:
-    uses: ./.github/workflows/lint.yml
-
-  prettier:
-    uses: ./.github/workflows/prettier.yml
-
-  test:
-    uses: ./.github/workflows/test.yml
-
   confirmPassingBuild:
     runs-on: ubuntu-latest
-    needs: [typecheck, lint, test]
-    if: ${{ always() }}
-
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Announce failed workflow in Slack
-        if: ${{ needs.typecheck.result == 'failure' || needs.lint.result == 'failure' || needs.test.result == 'failure' }}
-        uses: ./.github/actions/composite/announceFailedWorkflowInSlack
-        with:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-
-      - name: Exit failed workflow
-        if: ${{ needs.typecheck.result == 'failure' || needs.lint.result == 'failure' || needs.test.result == 'failure' }}
-        run: |
-          echo "Checks failed, exiting ~ typecheck: ${{ needs.typecheck.result }}, lint: ${{ needs.lint.result }}, test: ${{ needs.test.result }}"
-          exit 1
+      - name: Mock this job
+        run: echo "Yay, tests passed!"
 
   chooseDeployActions:
     runs-on: ubuntu-latest
@@ -90,11 +64,3 @@ jobs:
     secrets: inherit
     with:
       TARGET_BRANCH: staging
-
-  e2ePerformanceTests:
-    needs: [chooseDeployActions]
-    if: ${{ needs.chooseDeployActions.outputs.SHOULD_DEPLOY }}
-    uses: ./.github/workflows/e2ePerformanceTests.yml
-    secrets: inherit
-    with:
-      PR_NUMBER: ${{ needs.chooseDeployActions.outputs.MERGED_PR }}

--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -58,6 +58,7 @@ jobs:
           # Re-create the target branch from the source branch
           git switch -c ${{ inputs.TARGET_BRANCH }}
 
+          # Commit the change to the Mobile-Expensify submodule
           cd Mobile-Expensify
           MOBILE_EXPENSIFY_HEAD="$(git rev-parse --short HEAD)"
           cd ..

--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -68,3 +68,9 @@ jobs:
           git push --force origin ${{ inputs.TARGET_BRANCH }}
 
           echo "::notice::New HEAD of E/App ${{ inputs.TARGET_BRANCH}}: $(git log -1 --pretty=format:"%h \"%s\" by %an")"
+
+      - name: Announce failed workflow in Slack
+        if: ${{ failure() }}
+        uses: ./.github/actions/composite/announceFailedWorkflowInSlack
+        with:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -24,4 +24,44 @@ jobs:
             exit 1
           fi
 
-      - name:  
+      - name: Checkout source branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.getSourceBranch.outputs.SOURCE_BRANCH }}
+          token: ${{ secrets.OS_BOTIFY_TOKEN }}
+          submodules: true
+
+      - name: Setup git for OSBotify
+        uses: Expensify/GitHub-Actions/setupGitForOSBotify@main
+        id: setupGitForOSBotify
+        with:
+          OP_VAULT: ${{ vars.OP_VAULT }}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SETUP_AS_APP: false
+
+      - name: Update target branch in Mobile-Expensify
+        working-directory: Mobile-Expensify
+        run: |
+          # Re-create the target branch from the source branch
+          git switch -c ${{ inputs.TARGET_BRANCH }}
+
+          # Force-update the remote target branch.
+          git push --force origin ${{ inputs.TARGET_BRANCH }}
+
+          echo "::notice::New HEAD of Mobile-Expensify ${{ inputs.TARGET_BRANCH}}: $(git log -1 --pretty=format:"%h \"%s\" by %an")"
+
+      - name: Update target branch in E/App
+        run: |
+          # Re-create the target branch from the source branch
+          git switch -c ${{ inputs.TARGET_BRANCH }}
+
+          cd Mobile-Expensify
+          MOBILE_EXPENSIFY_HEAD="$(git rev-parse --short HEAD)"
+          cd ..
+          git add Mobile-Expensify
+          git commit -m "Update Mobile-Expensify submodule to $MOBILE_EXPENSIFY_HEAD"
+
+          # Force-update the remote target branch.
+          git push --force origin ${{ inputs.TARGET_BRANCH }}
+
+          echo "::notice::New HEAD of E/App ${{ inputs.TARGET_BRANCH}}: $(git log -1 --pretty=format:"%h \"%s\" by %an")"

--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -1,0 +1,27 @@
+name: Update Protected Branch
+
+on:
+  workflow_call:
+    inputs:
+      TARGET_BRANCH:
+        description: 'Which branch to update. Should be one of: [staging, production]'
+        required: true
+        type: string
+
+jobs:
+  updateProtectedBranch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine SOURCE_BRANCH
+        id: getSourceBranch
+        run: |
+          if [[ '${{ inputs.TARGET_BRANCH }}' == 'staging' ]]; then
+            echo "SOURCE_BRANCH=main" >> "$GITHUB_OUTPUT"
+          elif [[ '${{ inputs.TARGET_BRANCH }}' == 'production' ]]; then
+            echo "SOURCE_BRANCH=staging" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::💥 Invalid TARGET_BRANCH ${{ inputs.TARGET_BRANCH }}"
+            exit 1
+          fi
+
+      - name:  

--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.TARGET_BRANCH }}
+
 jobs:
   updateProtectedBranch:
     runs-on: ubuntu-latest

--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -58,14 +58,6 @@ jobs:
           # Re-create the target branch from the source branch
           git switch -c ${{ inputs.TARGET_BRANCH }}
 
-          # Commit the change to the Mobile-Expensify submodule
-          cd Mobile-Expensify
-          git checkout ${{ inputs.TARGET_BRANCH }}
-          MOBILE_EXPENSIFY_HEAD="$(git rev-parse --short HEAD)"
-          cd ..
-          git add Mobile-Expensify
-          git commit -m "Update Mobile-Expensify submodule to $MOBILE_EXPENSIFY_HEAD"
-
           # Force-update the remote target branch.
           git push --force origin ${{ inputs.TARGET_BRANCH }}
 

--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -60,6 +60,7 @@ jobs:
 
           # Commit the change to the Mobile-Expensify submodule
           cd Mobile-Expensify
+          git checkout ${{ inputs.TARGET_BRANCH }}
           MOBILE_EXPENSIFY_HEAD="$(git rev-parse --short HEAD)"
           cd ..
           git add Mobile-Expensify


### PR DESCRIPTION
### Explanation of Change
Design doc section: https://docs.google.com/document/d/14T1_OyWm3wwbPWQ5rO43FsGOd568Y9lAXS7YYToOZSE/edit?tab=t.0#bookmark=id.3mtm8xsbc562

Syncing the branch dance in Mobile-Expensify and E/App.

### Fixed Issues
$ https://github.com/Expensify/App/issues/55403

### Tests

#### Setup
1. Create a test checklist in this repo.
    - _Note:_ You can do this by hardcoding your GitHub PAT [here](https://github.com/Expensify/App-Test-Fork/blob/a5902fb737cfdbd693f4348adfc126b9d89ca068/.github/libs/GithubUtils.ts#L103), then run `ts-node .github/actions/javascript/createOrUpdateStagingDeploy/createOrUpdateStagingDeploy.ts`
    - *Edit:* I ended up using node w/ `GITHUB_REPOSITORY='Expensify/App-Test-Fork' node .github/actions/javascript/createOrUpdateStagingDeploy/index.js`
    - **Result:** I had to do a few other hacks to get the first empty checklist created, but here it is: https://github.com/Expensify/App-Test-Fork/issues/15
1. Ensure that main, staging, and production in this repo are all the same. Make sure the Mobile-Expensify submodule in each branch is pointing at Mobile-Expensify-Test-Fork.
1. Merge this PR and kill `preDeploy.yml` to make later testing steps clearer.
1. Make sure that main, staging, and production in Mobile-Expensify-Test-Fork are all the same.

#### Main tests
1. Merge a dummy PR into Mobile-Expensify-Test-Fork main. Validate that:
    - App-Test-Fork main is updated to point at the new HEAD of Mobile-Expensify-Test-Fork main
    - Mobile-Expensify-Test-Fork staging is unchanged
    - **Results:**
      
1. Merge a dummy PR into App-Test-Fork main to trigger a staging deploy and add that PR to the checklist. Validate that:
    - The Mobile-Expensify-Test-Fork dummy PR is now present on Mobile-Expensify-Test-Fork staging
    - The App-Test-Fork dummy PR is present on App-Test-Fork staging
    - The Mobile-Expensify submodule in App-Test-Fork staging is pointing at the latest commit in Mobile-Expensify-Test-Fork staging
    - **Results:**
1. Lock the checklist
1. Merge another PR to App-Test-Fork main so we know that there are changes on main that are not on staging. Validate that App-Test-Fork staging is unchanged.
1. Merge another dummy PR to Mobile-Expensify-Test-Fork main. Validate that:
    - App-Test-Fork main is updated to point at the latest commit in Mobile-Expensify-Test-Fork main
    - Mobile-Expensify-Test-Fork staging is unchanged
1. Close the checklist with the `:shipit:` squirrel. Validate that:
    - Mobile-Expensify-Test-Fork production is updated to have the same commit that was previously HEAD on Mobile-Expensify-Test-Fork staging
    - App-Test-Fork production is updated to have the same commit that was previously HEAD on App-Test-Fork staging
    - The Mobile-Expensify submodule of App-Test-Fork production is pointing at the latest commit on Mobile-Expensify-Test-Fork production
    - Mobile-Expensify-Test-Fork staging is updated to have the same commit that was previously HEAD on Mobile-Expensify-Test-Fork main
    - App-Test-Fork staging is updated to have the same commit that was previously HEAD on App-Test-Fork main
    - the Mobile-Expensify submodule of App-Test-Fork staging is pointing at the latest commit on Mobile-Expensify-Test-Fork staging
    - A new checklist is created with the latest App-Test-Fork dummy PR.