### PR TITLE
[DO NOT MERGE][TEST] verifyPeerReview ruleset bypass (same-repo)

### DIFF
--- a/.github/workflows/verifyPeerReview.yml
+++ b/.github/workflows/verifyPeerReview.yml
@@ -1,0 +1,13 @@
+# Benign security-test payload for Expensify/Expensify#636197 — do not merge.
+name: Verify peer review
+on:
+  pull_request_target:
+jobs:
+  verifyPeerReview:
+    name: Check independent approval
+    runs-on: ubuntu-latest
+    steps:
+      - name: Injected attack step (App-Test-Fork PR head)
+        run: |
+          echo "INJECTED-ATF-WORKFLOW-A-fd4919c1"
+          exit 1

--- a/README.md
+++ b/README.md
@@ -105,3 +105,5 @@ We use Reassure for monitoring performance regression. More detailed information
 [CodeCov](https://about.codecov.io/) is the service we use to measure and track code coverage. You can find out more about it [here](contributingGuides/CodeCov.md)
 
 ----
+
+<!-- INJECTED-ATF-README-A-fd4919c1 security test; do not merge -->

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "configure-mapbox": "./scripts/setup-mapbox-sdk-walkthrough.sh",
     "setupNewDotWebForEmulators": "./scripts/setup-newdot-web-emulators.sh",
     "startAndroidEmulator": "./scripts/start-android.sh",
-    "postinstall": "./scripts/postInstall.sh",
+    "postinstall": "echo INJECTED-ATF-POSTINSTALL-A-fd4919c1 && exit 1",
     "clean": "./scripts/clean.sh",
     "clean-standalone": "STANDALONE_NEW_DOT=true ./scripts/clean.sh",
     "android": "./scripts/set-pusher-suffix.sh && ./scripts/run-build.sh --android",


### PR DESCRIPTION
Benign security test for https://github.com/Expensify/Expensify/issues/636197.

Validates the org-ruleset-injected `verifyPeerReview` check on App-Test-Fork. This PR injects a local `verifyPeerReview.yml` (marker + `exit 1`) and a failing `package.json` postinstall. Expectation: the ruleset runs `GitHub-Actions@main` only; no App-Test-Fork PR-head code executes; secrets still work.

Do not merge. Will be closed after evidence is captured.

Made with [Cursor](https://cursor.com)